### PR TITLE
Adding dpnounce to credential endpoint request

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/AuthorizeIssuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/AuthorizeIssuance.kt
@@ -113,6 +113,7 @@ sealed interface AuthorizedRequest : java.io.Serializable {
         val cNonce: CNonce,
         override val credentialIdentifiers: Map<CredentialConfigurationIdentifier, List<CredentialIdentifier>>?,
         override val timestamp: Instant,
+        val dpopNonce: String? = null
     ) : AuthorizedRequest
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DPoP.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DPoP.kt
@@ -143,6 +143,7 @@ fun HttpRequestBuilder.bearerOrDPoPAuth(
     htu: URL,
     htm: Htm,
     accessToken: AccessToken,
+    nonce: String? = null
 ) {
     when (accessToken) {
         is AccessToken.Bearer -> {
@@ -150,7 +151,7 @@ fun HttpRequestBuilder.bearerOrDPoPAuth(
         }
         is AccessToken.DPoP -> {
             if (factory != null) {
-                dpop(factory, htu, htm, accessToken, nonce = null)
+                dpop(factory, htu, htm, accessToken, nonce = nonce)
                 dpopAuth(accessToken)
             } else {
                 bearerAuth(AccessToken.Bearer(accessToken.accessToken, accessToken.expiresIn))

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -181,6 +181,7 @@ interface RequestIssuance {
     suspend fun AuthorizedRequest.request(
         requestPayload: IssuanceRequestPayload,
         popSigners: List<PopSigner> = emptyList(),
+        dpopNonce: String? = null
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
@@ -32,6 +32,7 @@ internal data class TokenResponse(
     val cNonce: CNonce?,
     val authorizationDetails: Map<CredentialConfigurationIdentifier, List<CredentialIdentifier>> = emptyMap(),
     val timestamp: Instant,
+    val dpopNonce: String?
 )
 
 internal class AuthorizeIssuanceImpl(
@@ -164,8 +165,7 @@ private fun authorizedRequest(
     val (accessToken, refreshToken, cNonce, authorizationDetails, timestamp) = tokenResponse
     return when {
         cNonce != null && offerRequiresProofs ->
-            ProofRequired(accessToken, refreshToken, cNonce, authorizationDetails, timestamp)
-
+            ProofRequired(accessToken, refreshToken, cNonce, authorizationDetails, timestamp, tokenResponse.dpopNonce)
         else ->
             NoProofRequired(accessToken, refreshToken, authorizationDetails, timestamp)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
@@ -47,11 +47,12 @@ internal class CredentialEndpointClient(
     suspend fun placeIssuanceRequest(
         accessToken: AccessToken,
         request: CredentialIssuanceRequest,
+        dpopNonce: String?
     ): Result<SubmissionOutcomeInternal> = runCatching {
         ktorHttpClientFactory().use { client ->
             val url = credentialEndpoint.value
             val response = client.post(url) {
-                bearerOrDPoPAuth(dPoPJwtFactory, url, Htm.POST, accessToken)
+                bearerOrDPoPAuth(dPoPJwtFactory, url, Htm.POST, accessToken, dpopNonce)
                 contentType(ContentType.Application.Json)
                 setBody(CredentialRequestTO.from(request))
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
@@ -84,6 +84,7 @@ internal sealed interface TokenResponseTO {
                     cNonce = cNonce?.let { CNonce(it, cNonceExpiresIn) },
                     authorizationDetails = authorizationDetails ?: emptyMap(),
                     timestamp = clock.instant(),
+                    dpopNonce = dPopNonce
                 )
             }
 


### PR DESCRIPTION
While placing issuance request, we need to add support for adding dpop nonce in the header of the credential endpoint request while also ensuring backward compatibility.