### PR TITLE
fix: Add missing alg field to CredentialResponseEncryptionSpecTO

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceRequestJsonMapper.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceRequestJsonMapper.kt
@@ -33,19 +33,21 @@ import kotlin.time.toDuration
 @Serializable
 internal data class CredentialResponseEncryptionSpecTO(
     @SerialName("jwk") val jwk: JsonObject,
+    @SerialName("alg") val algorithm: String,
     @SerialName("enc") val encryptionMethod: String,
     @SerialName("zip") val compressionAlgorithm: String? = null,
-
 ) {
     companion object {
 
         fun from(responseEncryption: EncryptionSpec): CredentialResponseEncryptionSpecTO {
             val credentialEncryptionJwk =
                 Json.parseToJsonElement(responseEncryption.recipientKey.toPublicJWK().toString()).jsonObject
+            val credentialResponseEncryptionAlgorithm = responseEncryption.recipientKey.algorithm.name
             val credentialResponseEncryptionMethod = responseEncryption.encryptionMethod.toString()
             val encryptedPayloadCompressionAlgorithm = responseEncryption.compressionAlgorithm?.toString()
             return CredentialResponseEncryptionSpecTO(
                 credentialEncryptionJwk,
+                credentialResponseEncryptionAlgorithm,
                 credentialResponseEncryptionMethod,
                 encryptedPayloadCompressionAlgorithm,
             )


### PR DESCRIPTION
- Add 'alg' field to CredentialResponseEncryptionSpecTO data class
- Extract algorithm from EncryptionSpec.recipientKey.algorithm.name
- This ensures the credential request includes the asymmetric encryption algorithm (ECDH-ES)
- Fixes 'invalid_encryption_parameters' error from issuer backend

The OpenID4VCI specification requires the credential_response_encryption object to include:
- jwk: the public key
- alg: the asymmetric encryption algorithm (was missing)
- enc: the symmetric encryption method
- zip: optional compression

Without the alg field, the backend received 'undefined' as the algorithm value, causing issuance failures with error: 'Unsupported credential response encryption algorithm undefined'